### PR TITLE
Remove deprecated panel_iframe integration

### DIFF
--- a/blog/2022/09/home-assistant-container-part-3-mariadb-and-influxdb/index.html
+++ b/blog/2022/09/home-assistant-container-part-3-mariadb-and-influxdb/index.html
@@ -156,7 +156,7 @@ Adminer, formerly known as phpMyAdmin, can be used to connect to and manage the 
 </span></span><span style=display:flex><span>      - <span style=color:#e6db74>&#34;8080:8080/tcp&#34;</span>
 </span></span><span style=display:flex><span>    <span style=color:#f92672>depends_on</span>:
 </span></span><span style=display:flex><span>      - <span style=color:#ae81ff>mariadb</span>
-</span></span></code></pre></div><p>[iframe]: <a href=https://www.home-assistant.io/integrations/panel_iframe/ target=_blank rel=noopener>https://www.home-assistant.io/integrations/panel_iframe/</a> &ldquo;iframe Panel integration</p></div></article><hr><div class=post-info><p><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentcolor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-tag meta-icon"><path d="M20.59 13.41l-7.17 7.17a2 2 0 01-2.83.0L2 12V2h10l8.59 8.59a2 2 0 010 2.82z"/><line x1="7" y1="7" x2="7" y2="7"/></svg>
+</span></span></code></pre></div></div></article><hr><div class=post-info><p><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentcolor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-tag meta-icon"><path d="M20.59 13.41l-7.17 7.17a2 2 0 01-2.83.0L2 12V2h10l8.59 8.59a2 2 0 010 2.82z"/><line x1="7" y1="7" x2="7" y2="7"/></svg>
 <span class=tag><a href=https://sequr.be/tags/home-automation/>Home Automation</a></span>
 <span class=tag><a href=https://sequr.be/tags/home-assistant/>Home Assistant</a></span>
 <span class=tag><a href=https://sequr.be/tags/container/>Container</a></span>


### PR DESCRIPTION
Use Dashboards instead:

1. Go to Dashboards: https://my.home-assistant.io/redirect/lovelace_dashboards/
2. Add dashboard > Webpage
3. Enter URL 
4. Set Title, Icon, Admin only

see https://github.com/home-assistant/home-assistant.io/issues/32162

Awesome blog posts, very informative! Please remove the deprecated `panel_iframe` integration from these blogposts:  https://github.com/search?q=repo%3ATheGroundZero%2FTheGroundZero.github.io%20panel_iframe&type=code

Couln't create an issue, so I created a pull request. ;)